### PR TITLE
Configure Vite for GitHub Pages deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "homepage": "https://abou-cell.github.io/livewebmoon",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "deploy": "gh-pages -d dist"
   },
   "dependencies": {
     "firebase": "^12.0.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/livewebmoon/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- set Vite base path for GitHub Pages
- add homepage and deploy script to package.json

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: hung after warning about http-proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688fd0f7185883289e9921c1c2d490b2