### PR TITLE
chore: configure package.json for deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "livewebmoon",
   "version": "1.0.0",
+  "private": true,
   "scripts": {
     "dev": "vite",
     "build": "vite build",
@@ -8,9 +9,9 @@
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {
+    "firebase": "^10.0.0",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0",
-    "firebase": "^10.0.0"
+    "react-dom": "^18.0.0"
   },
   "devDependencies": {
     "vite": "^4.0.0",


### PR DESCRIPTION
## Summary
- add missing `private` flag
- ensure deployment scripts and homepage are set

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_688fe5d32d508328b93d3620a409d643