### PR TITLE
Handle auth loading and errors with placeholder content

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,9 @@
     <title>Vite + React</title>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <p>Application en cours de chargement...</p>
+    </div>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,12 +2,39 @@ import { useEffect, useState } from "react";
 import { onAuthStateChanged } from "firebase/auth";
 import { auth } from "./firebase/firebaseConfig.js";
 import Login from "./components/Login.jsx";
+
 function App() {
   const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
 
   useEffect(() => {
-    return onAuthStateChanged(auth, (u) => setUser(u));
+    if (!auth) {
+      setError("Configuration Firebase manquante.");
+      setLoading(false);
+      return;
+    }
+    const unsubscribe = onAuthStateChanged(
+      auth,
+      (u) => {
+        setUser(u);
+        setLoading(false);
+      },
+      (err) => {
+        setError(err.message);
+        setLoading(false);
+      }
+    );
+    return () => unsubscribe();
   }, []);
+
+  if (loading) {
+    return <div className="text-center p-10">Chargement...</div>;
+  }
+
+  if (error) {
+    return <div className="text-center p-10 text-red-500">{error}</div>;
+  }
 
   return user ? (
     <div className="text-center p-10">


### PR DESCRIPTION
## Summary
- Display a placeholder message during initial load so the start page isn't blank
- Add loading and error handling around Firebase auth to show meaningful messages instead of an empty screen

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)

------
https://chatgpt.com/codex/tasks/task_e_68909be5f3c48328b5e5779766e3257c