### PR TITLE
feat: add public home page with navigation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import Login from "./components/Login";
 import Dashboard from "./components/Dashboard";
 import StreamerPanel from "./components/StreamerPanel";
 import StreamPlayer from "./components/StreamPlayer";
+import Home from "./components/Home";
 
 const PrivateRoute = ({ children }) => {
   const { user, loading } = useAuth();
@@ -22,8 +23,9 @@ function App() {
       <BrowserRouter>
         <Routes>
           <Route path="/login" element={<Login />} />
+          <Route path="/" element={<Home />} />
           <Route
-            path="/"
+            path="/dashboard"
             element={
               <PrivateRoute>
                 <Dashboard />

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -1,0 +1,59 @@
+import { Link } from "react-router-dom";
+import Navbar from "./Navbar";
+
+const mockStreams = [
+  {
+    id: "1",
+    title: "Live Coding Session",
+    thumbnail: "https://via.placeholder.com/300x200?text=Stream+1",
+  },
+  {
+    id: "2",
+    title: "Music Live",
+    thumbnail: "https://via.placeholder.com/300x200?text=Stream+2",
+  },
+];
+
+const Home = () => {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <section className="flex flex-col items-center justify-center text-center py-16 bg-gray-50">
+        <h1 className="text-4xl font-bold text-violet-600 mb-4">LiveWebMoon</h1>
+        <p className="mb-8 text-lg">Explore live streams from around the world.</p>
+        <div className="flex gap-4">
+          <Link
+            to="/login"
+            className="px-4 py-2 bg-violet-500 text-white rounded-md shadow-md transition hover:scale-105"
+          >
+            Login
+          </Link>
+          <Link
+            to="/streamer"
+            className="px-4 py-2 bg-violet-500 text-white rounded-md shadow-md transition hover:scale-105"
+          >
+            Streamer Panel
+          </Link>
+        </div>
+      </section>
+      <section className="p-8 grid gap-6 md:grid-cols-2">
+        {mockStreams.map((stream) => (
+          <div key={stream.id} className="bg-white rounded-md shadow-md overflow-hidden">
+            <img src={stream.thumbnail} alt={stream.title} className="w-full h-48 object-cover" />
+            <div className="p-4 flex justify-between items-center">
+              <h3 className="text-lg font-semibold">{stream.title}</h3>
+              <Link
+                to={`/stream/${stream.id}`}
+                className="px-4 py-2 bg-violet-500 text-white rounded-md shadow-md transition hover:scale-105"
+              >
+                Join
+              </Link>
+            </div>
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+};
+
+export default Home;

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { useAuth } from "../hooks/useAuth";
+import { useNavigate } from "react-router-dom";
 
 const Login = () => {
   const { signIn, register } = useAuth();
+  const navigate = useNavigate();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -11,6 +13,7 @@ const Login = () => {
     e.preventDefault();
     try {
       await signIn(email, password);
+      navigate("/dashboard");
     } catch (err) {
       setError(err.message);
     }
@@ -20,6 +23,7 @@ const Login = () => {
     e.preventDefault();
     try {
       await register(email, password);
+      navigate("/dashboard");
     } catch (err) {
       setError(err.message);
     }

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,0 +1,19 @@
+import { Link } from "react-router-dom";
+
+const Navbar = () => {
+  return (
+    <nav className="p-4 bg-white shadow-md flex gap-4">
+      <Link to="/" className="text-violet-600 font-bold">
+        Home
+      </Link>
+      <Link to="/login" className="text-violet-600">
+        Login
+      </Link>
+      <Link to="/streamer" className="text-violet-600">
+        Streamer Panel
+      </Link>
+    </nav>
+  );
+};
+
+export default Navbar;


### PR DESCRIPTION
## Summary
- add public Home component with mock livestream cards
- create Navbar and update routing to include Home and dashboard path
- redirect users to dashboard after login or registration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890d850d1b88328b1077206c201781d