### PR TITLE
Integrate navbar globally and clean up Home component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import Dashboard from "./components/Dashboard";
 import StreamerPanel from "./components/StreamerPanel";
 import StreamPlayer from "./components/StreamPlayer";
 import Home from "./components/Home";
+import Navbar from "./components/Navbar";
 
 const PrivateRoute = ({ children }) => {
   const { user, loading } = useAuth();
@@ -21,6 +22,7 @@ function App() {
   return (
     <AuthProvider>
       <BrowserRouter>
+        <Navbar />
         <Routes>
           <Route path="/login" element={<Login />} />
           <Route path="/" element={<Home />} />

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -1,5 +1,4 @@
 import { Link } from "react-router-dom";
-import Navbar from "./Navbar";
 
 const mockStreams = [
   {
@@ -17,7 +16,6 @@ const mockStreams = [
 const Home = () => {
   return (
     <div className="min-h-screen flex flex-col">
-      <Navbar />
       <section className="flex flex-col items-center justify-center text-center py-16 bg-gray-50">
         <h1 className="text-4xl font-bold text-violet-600 mb-4">LiveWebMoon</h1>
         <p className="mb-8 text-lg">Explore live streams from around the world.</p>


### PR DESCRIPTION
## Summary
- Render Navbar at the top level to provide consistent navigation across routes
- Simplify Home by removing internal Navbar and keeping navigation links and livestreams

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890e94d17948328ab9a5b64e7acfad2