### PR TITLE
fix router base for gh pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,9 +19,10 @@ const StreamPlayerWrapper = () => {
 };
 
 function App() {
+  const basename = import.meta.env.BASE_URL.replace(/\/$/, '');
   return (
     <AuthProvider>
-      <BrowserRouter>
+      <BrowserRouter basename={basename}>
         <Navbar />
         <Routes>
           <Route path="/login" element={<Login />} />

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: '/livewebmoon/',
+  base: process.env.NODE_ENV === 'production' ? '/livewebmoon/' : '/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- fix Vite base path configuration for GitHub Pages builds
- pass repo base path to BrowserRouter so routes work under `/livewebmoon`

## Testing
- `npm test`
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890fffdf2a48328bcf8c386ef243382