### PR TITLE
Fix base paths for GitHub Pages deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="./vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <title>LiveWebMoon</title>
@@ -11,6 +11,6 @@
     <div id="root">
       <p>Application en cours de chargement...</p>
     </div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
-export default defineConfig({
-  base: process.env.NODE_ENV === 'production' ? '/livewebmoon/' : '/',
+export default defineConfig(({ command }) => ({
+  base: command === 'build' ? '/livewebmoon/' : '/',
   plugins: [react()],
-})
+}))


### PR DESCRIPTION
## Summary
- use build command to apply `/livewebmoon/` base
- make entry and icon paths relative for GitHub Pages

## Testing
- `npm test`
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68910e10ac248328a2608b9a06131480