### PR TITLE
style: apply Stripe-inspired design

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -17,23 +17,23 @@ const Dashboard = () => {
       <Header />
       <h2 className="text-xl mb-4">Bonjour {user?.email}</h2>
       <div className="mb-4">Crédits: {credits}</div>
-      <button className="mb-6 px-4 py-2 bg-violet-500 text-white rounded-md shadow-md transition hover:scale-105">
-        Recharger mes crédits
-      </button>
+        <button className="mb-6 px-4 py-2 bg-primary text-white rounded-2xl shadow-lg transition hover:scale-105">
+          Recharger mes crédits
+        </button>
       <ul className="space-y-2">
         {streams.map((s) => (
-          <li
-            key={s.id}
-            className="p-4 bg-white rounded-md shadow-md flex justify-between items-center"
-          >
-            <span>{s.title}</span>
-            <button
-              onClick={() => navigate(`/stream/${s.id}`)}
-              className="px-4 py-2 bg-violet-500 text-white rounded-md shadow-md transition hover:scale-105"
+            <li
+              key={s.id}
+              className="p-4 bg-white rounded-2xl shadow-lg flex justify-between items-center"
             >
-              Rejoindre le live
-            </button>
-          </li>
+              <span>{s.title}</span>
+              <button
+                onClick={() => navigate(`/stream/${s.id}`)}
+                className="px-4 py-2 bg-primary text-white rounded-2xl shadow-lg transition hover:scale-105"
+              >
+                Rejoindre le live
+              </button>
+            </li>
         ))}
       </ul>
     </div>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -3,15 +3,15 @@ import { useAuth } from "../hooks/useAuth";
 const Header = () => {
   const { logout } = useAuth();
   return (
-    <header className="p-4 bg-white shadow-md flex justify-between items-center mb-4">
-      <h1 className="text-xl font-bold text-violet-600">LiveWebMoon</h1>
-      <button
-        onClick={logout}
-        className="px-4 py-2 bg-violet-500 text-white rounded-md shadow-md transition hover:scale-105"
-      >
-        Déconnexion
-      </button>
-    </header>
+      <header className="p-4 bg-white shadow-lg rounded-2xl flex justify-between items-center mb-4">
+        <h1 className="text-xl font-bold text-primary">LiveWebMoon</h1>
+        <button
+          onClick={logout}
+          className="px-4 py-2 bg-primary text-white rounded-2xl shadow-lg transition hover:scale-105"
+        >
+          Déconnexion
+        </button>
+      </header>
   );
 };
 

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -42,7 +42,7 @@ const features = [
 const Home = () => {
   return (
     <div className="min-h-screen flex flex-col">
-      <section className="bg-gradient-to-r from-violet-600 to-indigo-600 text-white text-center py-20">
+      <section className="bg-primary text-white text-center py-20">
         <h1 className="text-5xl font-extrabold mb-4">LiveWebMoon</h1>
         <p className="mb-8 text-lg">
           La plateforme communautaire pour regarder et partager des livestreams.
@@ -50,13 +50,13 @@ const Home = () => {
         <div className="space-x-4">
           <Link
             to="/login"
-            className="px-6 py-3 bg-white text-violet-600 rounded-md shadow-lg transition hover:scale-105"
+            className="px-6 py-3 bg-white text-primary rounded-2xl shadow-lg transition hover:scale-105"
           >
             Connexion
           </Link>
           <Link
             to="/streamer"
-            className="px-6 py-3 bg-white text-violet-600 rounded-md shadow-lg transition hover:scale-105"
+            className="px-6 py-3 bg-white text-primary rounded-2xl shadow-lg transition hover:scale-105"
           >
             Démarrer un stream
           </Link>
@@ -67,7 +67,7 @@ const Home = () => {
         {features.map((feature) => (
           <div
             key={feature.title}
-            className="bg-white rounded-md shadow-md p-6 flex flex-col transition transform hover:scale-105"
+            className="bg-white rounded-2xl shadow-lg p-6 flex flex-col transition transform hover:scale-105"
           >
             <h3 className="text-xl font-semibold mb-2 flex items-center">
               <span className="text-2xl mr-2">{feature.icon}</span>
@@ -76,7 +76,7 @@ const Home = () => {
             <p className="flex-grow mb-4">{feature.description}</p>
             <Link
               to={feature.link}
-              className="self-start px-4 py-2 bg-violet-500 text-white rounded-md shadow-md transition hover:scale-105"
+              className="self-start px-4 py-2 bg-primary text-white rounded-2xl shadow-lg transition hover:scale-105"
             >
               {feature.action}
             </Link>
@@ -86,32 +86,32 @@ const Home = () => {
 
       <section className="p-8 bg-gray-50 flex-1">
         <h2 className="text-2xl font-bold mb-4">Streams populaires</h2>
-        <div className="grid gap-6 md:grid-cols-2">
-          {mockStreams.map((stream) => (
-            <div key={stream.id} className="bg-white rounded-md shadow-md overflow-hidden">
-              <img
-                src={stream.thumbnail}
-                alt={stream.title}
-                className="w-full h-48 object-cover"
-              />
-              <div className="p-4 flex justify-between items-center">
-                <div>
-                  <h3 className="text-lg font-semibold">{stream.title}</h3>
-                  <p className="text-sm text-gray-500">{stream.viewers} spectateurs</p>
+          <div className="grid gap-6 md:grid-cols-2">
+            {mockStreams.map((stream) => (
+              <div key={stream.id} className="bg-white rounded-2xl shadow-lg overflow-hidden">
+                <img
+                  src={stream.thumbnail}
+                  alt={stream.title}
+                  className="w-full h-48 object-cover"
+                />
+                <div className="p-4 flex justify-between items-center">
+                  <div>
+                    <h3 className="text-lg font-semibold">{stream.title}</h3>
+                    <p className="text-sm text-gray-500">{stream.viewers} spectateurs</p>
+                  </div>
+                  <Link
+                    to={`/stream/${stream.id}`}
+                    className="px-4 py-2 bg-primary text-white rounded-2xl shadow-lg transition hover:scale-105"
+                  >
+                    Rejoindre
+                  </Link>
                 </div>
-                <Link
-                  to={`/stream/${stream.id}`}
-                  className="px-4 py-2 bg-violet-500 text-white rounded-md shadow-md transition hover:scale-105"
-                >
-                  Rejoindre
-                </Link>
               </div>
-            </div>
-          ))}
-        </div>
-      </section>
-    </div>
-  );
-};
+            ))}
+          </div>
+        </section>
+      </div>
+    );
+  };
 
 export default Home;

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -31,36 +31,36 @@ const Login = () => {
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-gray-50">
-      <form className="bg-white p-8 rounded-lg shadow-md w-full max-w-md space-y-4">
-        <h2 className="text-2xl font-bold text-center text-violet-600">Login</h2>
+      <form className="bg-white p-8 rounded-2xl shadow-lg w-full max-w-md space-y-4">
+        <h2 className="text-2xl font-bold text-center text-primary">Login</h2>
         {error && <p className="text-red-500 text-sm">{error}</p>}
-        <input
-          type="email"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          className="w-full p-2 border rounded-md"
-        />
-        <input
-          type="password"
-          placeholder="Mot de passe"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          className="w-full p-2 border rounded-md"
-        />
+          <input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full p-2 border rounded-lg"
+          />
+          <input
+            type="password"
+            placeholder="Mot de passe"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full p-2 border rounded-lg"
+          />
         <div className="flex gap-2">
-          <button
-            onClick={handleLogin}
-            className="flex-1 bg-violet-500 text-white p-2 rounded-md hover:bg-violet-600 transition"
-          >
-            Login
-          </button>
-          <button
-            onClick={handleRegister}
-            className="flex-1 bg-gray-200 text-gray-700 p-2 rounded-md hover:bg-gray-300 transition"
-          >
-            Register
-          </button>
+            <button
+              onClick={handleLogin}
+              className="flex-1 bg-primary text-white p-2 rounded-2xl hover:bg-primary/90 transition shadow-lg"
+            >
+              Login
+            </button>
+            <button
+              onClick={handleRegister}
+              className="flex-1 bg-gray-200 text-gray-700 p-2 rounded-2xl hover:bg-gray-300 transition shadow-lg"
+            >
+              Register
+            </button>
         </div>
       </form>
     </div>

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -2,14 +2,14 @@ import { Link } from "react-router-dom";
 
 const Navbar = () => {
   return (
-    <nav className="p-4 bg-white shadow-md flex gap-4">
-      <Link to="/" className="text-violet-600 font-bold">
+    <nav className="p-4 bg-white shadow-lg rounded-2xl flex gap-4">
+      <Link to="/" className="text-primary font-bold">
         Home
       </Link>
-      <Link to="/login" className="text-violet-600">
+      <Link to="/login" className="text-primary">
         Login
       </Link>
-      <Link to="/streamer" className="text-violet-600">
+      <Link to="/streamer" className="text-primary">
         Streamer Panel
       </Link>
     </nav>

--- a/src/components/StreamPlayer.js
+++ b/src/components/StreamPlayer.js
@@ -24,21 +24,21 @@ const StreamPlayer = ({ streamId }) => {
     return <div className="p-4">Plus de crédits.</div>;
   }
 
-  return (
-    <div className="p-4 bg-white rounded-md shadow-md">
-      <iframe
-        src={`https://videodelivery.net/${streamId}/iframe`}
-        className="w-full h-64 rounded-md"
-        allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-        allowFullScreen
-        title="player"
-      ></iframe>
-      <div className="mt-4 flex justify-between">
-        <span>Crédits: {credits}</span>
-        <span>Temps restant: {seconds}s</span>
+    return (
+      <div className="p-4 bg-white rounded-2xl shadow-lg">
+        <iframe
+          src={`https://videodelivery.net/${streamId}/iframe`}
+          className="w-full h-64 rounded-2xl"
+          allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+          title="player"
+        ></iframe>
+        <div className="mt-4 flex justify-between">
+          <span>Crédits: {credits}</span>
+          <span>Temps restant: {seconds}s</span>
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  };
 
 export default StreamPlayer;

--- a/src/components/StreamerPanel.js
+++ b/src/components/StreamerPanel.js
@@ -11,32 +11,32 @@ const StreamerPanel = () => {
   };
 
   return (
-    <div className="p-4">
-      <Header />
-      <button
-        onClick={handleCreate}
-        className="px-4 py-2 bg-violet-500 text-white rounded-md shadow-md transition hover:scale-105"
-      >
-        Créer mon live stream
-      </button>
-      {stream && (
-        <div className="mt-4 space-y-2">
+      <div className="p-4">
+        <Header />
+        <button
+          onClick={handleCreate}
+          className="px-4 py-2 bg-primary text-white rounded-2xl shadow-lg transition hover:scale-105"
+        >
+          Créer mon live stream
+        </button>
+        {stream && (
+          <div className="mt-4 space-y-2">
           <div>
             <strong>URL RTMP:</strong> {stream.rtmpUrl}
           </div>
           <div>
             <strong>Stream Key:</strong> {stream.streamKey}
           </div>
-          <iframe
-            src={`https://videodelivery.net/${stream.id}/iframe`}
-            className="w-full h-64 rounded-md"
-            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-            allowFullScreen
-            title="stream"
-          ></iframe>
-        </div>
-      )}
-    </div>
+            <iframe
+              src={`https://videodelivery.net/${stream.id}/iframe`}
+              className="w-full h-64 rounded-2xl"
+              allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+              title="stream"
+            ></iframe>
+          </div>
+        )}
+      </div>
   );
 };
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,8 +3,7 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        primary: "#4f46e5",
-        secondary: "#f59e0b",
+        primary: "#635BFF",
       },
       fontFamily: {
         sans: ["Inter", "sans-serif"],


### PR DESCRIPTION
## Summary
- Refresh Tailwind config with Stripe’s primary #635BFF color
- Restyle landing, dashboard, auth, and streaming screens using rounded-2xl and shadow-lg for a Stripe-like aesthetic
- Align header and navbar with the new design system

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68911d205d74832894e282bfd762f858