### PR TITLE
fix: correct base paths for Vite build

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="./vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <title>LiveWebMoon</title>
@@ -11,6 +11,6 @@
     <div id="root">
       <p>Application en cours de chargement...</p>
     </div>
-    <script type="module" src="./src/main.jsx"></script>
+    <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,3 @@
+<script>
+  location.replace('/livewebmoon/');
+</script>


### PR DESCRIPTION
## Summary
- use absolute paths for Vite assets
- add redirecting 404 page for GitHub Pages

## Testing
- `npm test`
- `npm run build` *(fails: vite: not found; `npm install` failed with 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6893b07bec148328b552f6a8d04dc619