### PR TITLE
feat: add creator admin button to homepage

### DIFF
--- a/src/routes/Home.jsx
+++ b/src/routes/Home.jsx
@@ -82,6 +82,12 @@ export default function Home() {
           >
             ⚙️ Interface admin
           </Link>
+          <Link
+            to="/creator-admin"
+            className="px-6 py-3 bg-black text-white rounded-lg hover:bg-white hover:text-indigo-600 transition"
+          >
+            🧑‍💻 Interface créateur
+          </Link>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- add direct link to creator admin interface in homepage CTA

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68967777e55483289922bf02a3a7db79