### PR TITLE
feat: add subscriber button on homepage

### DIFF
--- a/src/routes/Home.jsx
+++ b/src/routes/Home.jsx
@@ -88,6 +88,12 @@ export default function Home() {
           >
             🧑‍💻 Interface créateur
           </Link>
+          <Link
+            to="/subscriber"
+            className="px-6 py-3 bg-black text-white rounded-lg hover:bg-white hover:text-indigo-600 transition"
+          >
+            👤 Interface abonné
+          </Link>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- add direct link to subscriber interface from homepage hero section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68973dbbe16c8328ab6f12be0918f3c2